### PR TITLE
Get prof shared true

### DIFF
--- a/src/main/java/com/NoviBackend/WalletWatch/security/SpringSecurityConfig.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/security/SpringSecurityConfig.java
@@ -74,6 +74,7 @@ public class SpringSecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/prof/**").hasRole("PROF")
                 .requestMatchers(HttpMethod.POST, "/prof/**").hasRole("PROF")
                 .requestMatchers(HttpMethod.POST, "/wallet").hasRole("PROF")
+                .requestMatchers(HttpMethod.GET, "/subscription").permitAll()
 
                 .anyRequest().denyAll()
                 .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);

--- a/src/main/java/com/NoviBackend/WalletWatch/subscription/Subscription.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/subscription/Subscription.java
@@ -12,9 +12,29 @@ public class Subscription {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
-    private int price;
-
-    @OneToOne
+    @ManyToOne
     private Wallet wallet;
+
+    public Subscription() {
+    }
+
+    public Subscription(Wallet wallet) {
+        this.wallet = wallet;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Wallet getWallet() {
+        return wallet;
+    }
+
+    public void setWallet(Wallet wallet) {
+        this.wallet = wallet;
+    }
 }

--- a/src/main/java/com/NoviBackend/WalletWatch/subscription/SubscriptionController.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/subscription/SubscriptionController.java
@@ -17,9 +17,8 @@ public class SubscriptionController {
 
     @GetMapping("/subscriptions")
     public List<Subscription> getAllsharedWallets(){
-        List<Subscription> subs = subscriptionService.getAllSharedProfs();
 
-        return subs;
+        return null;
     }
 
     @GetMapping("/subscription")

--- a/src/main/java/com/NoviBackend/WalletWatch/subscription/SubscriptionController.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/subscription/SubscriptionController.java
@@ -1,0 +1,24 @@
+package com.NoviBackend.WalletWatch.subscription;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Set;
+
+@RestController
+public class SubscriptionController {
+    private final SubscriptionService subscriptionService;
+
+    public SubscriptionController(SubscriptionService subscriptionService) {
+        this.subscriptionService = subscriptionService;
+    }
+
+    @GetMapping("/subscription")
+    public List<Subscription> getAllSharedWallets(Authentication auth){
+        List<Subscription> subs = subscriptionService.getSubscriptions(auth.getName());
+
+        return subs;
+    }
+}

--- a/src/main/java/com/NoviBackend/WalletWatch/subscription/SubscriptionController.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/subscription/SubscriptionController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.Set;
+
 
 @RestController
 public class SubscriptionController {
@@ -15,8 +15,15 @@ public class SubscriptionController {
         this.subscriptionService = subscriptionService;
     }
 
+    @GetMapping("/subscriptions")
+    public List<Subscription> getAllsharedWallets(){
+        List<Subscription> subs = subscriptionService.getAllSharedProfs();
+
+        return subs;
+    }
+
     @GetMapping("/subscription")
-    public List<Subscription> getAllSharedWallets(Authentication auth){
+    public List<Subscription> getSubscribedTo(Authentication auth){
         List<Subscription> subs = subscriptionService.getSubscriptions(auth.getName());
 
         return subs;

--- a/src/main/java/com/NoviBackend/WalletWatch/subscription/SubscriptionService.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/subscription/SubscriptionService.java
@@ -22,8 +22,4 @@ public class SubscriptionService {
         RegularUser user = regularUserService.findByUsername(name);
         return user.getSubscriptions();
     }
-
-    public List<Subscription> getAllSharedProfs() {
-        return null;
-    }
 }

--- a/src/main/java/com/NoviBackend/WalletWatch/subscription/SubscriptionService.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/subscription/SubscriptionService.java
@@ -22,4 +22,8 @@ public class SubscriptionService {
         RegularUser user = regularUserService.findByUsername(name);
         return user.getSubscriptions();
     }
+
+    public List<Subscription> getAllSharedProfs() {
+        return null;
+    }
 }

--- a/src/main/java/com/NoviBackend/WalletWatch/subscription/SubscriptionService.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/subscription/SubscriptionService.java
@@ -1,0 +1,25 @@
+package com.NoviBackend.WalletWatch.subscription;
+
+import com.NoviBackend.WalletWatch.user.regular.RegularUser;
+import com.NoviBackend.WalletWatch.user.regular.RegularUserService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+
+@Service
+public class SubscriptionService {
+    private final SubscriptionRepository subscriptionRepository;
+    private final RegularUserService regularUserService;
+
+    public SubscriptionService(SubscriptionRepository subscriptionRepository,
+                               RegularUserService regularUserService) {
+        this.subscriptionRepository = subscriptionRepository;
+        this.regularUserService = regularUserService;
+    }
+
+    public List<Subscription> getSubscriptions(String name) {
+        RegularUser user = regularUserService.findByUsername(name);
+        return user.getSubscriptions();
+    }
+}

--- a/src/main/java/com/NoviBackend/WalletWatch/user/AbstractUsers.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/user/AbstractUsers.java
@@ -8,8 +8,7 @@ import jakarta.validation.constraints.Email;
 import java.util.List;
 import java.util.Set;
 
-@Entity
-@Inheritance(strategy =  InheritanceType.JOINED)
+@MappedSuperclass
 public abstract class AbstractUsers {
 
     // attributes
@@ -34,7 +33,7 @@ public abstract class AbstractUsers {
     private Wallet personalWallet;
 
     @OneToMany
-    @JoinColumn(name = "subscribed_user_id")
+    @JoinColumn(name = "user_id")
     private List<Subscription> subscriptions;
 
 

--- a/src/main/java/com/NoviBackend/WalletWatch/user/AbstractUsers.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/user/AbstractUsers.java
@@ -7,12 +7,13 @@ import jakarta.validation.constraints.Email;
 
 import java.util.Set;
 
-@MappedSuperclass
+@Entity
+@Inheritance(strategy =  InheritanceType.JOINED)
 public abstract class AbstractUsers {
 
     // attributes
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
     @Column(nullable = false, unique = true)
@@ -46,7 +47,6 @@ public abstract class AbstractUsers {
         this.surname = surname;
         this.emailAddress = emailAddress;
         this.personalWallet = new Wallet();
-        // wallet needs to be saved.
     }
 
 

--- a/src/main/java/com/NoviBackend/WalletWatch/user/AbstractUsers.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/user/AbstractUsers.java
@@ -5,6 +5,7 @@ import com.NoviBackend.WalletWatch.wallet.Wallet;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -33,8 +34,8 @@ public abstract class AbstractUsers {
     private Wallet personalWallet;
 
     @OneToMany
-    @JoinColumn(name="subscriber_id")
-    private Set<Subscription> subscriptions;
+    @JoinColumn(name = "subscribed_user_id")
+    private List<Subscription> subscriptions;
 
 
     // constructor
@@ -95,7 +96,7 @@ public abstract class AbstractUsers {
         this.personalWallet = wallet;
     }
 
-    public Set<Subscription> getSubscriptions() {
+    public List<Subscription> getSubscriptions() {
         return subscriptions;
     }
 

--- a/src/main/java/com/NoviBackend/WalletWatch/user/professional/ProfUserController.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/user/professional/ProfUserController.java
@@ -22,8 +22,8 @@ public class ProfUserController {
     }
 
     @GetMapping("/profs")
-    public List<ProfessionalUsersDto> getAllProfessionals(){
-        List<ProfessionalUsersDto> listProfDto = profUserService.findAllProfsDto();
+    public List<ProfessionalUsersDto> getAllProfessionals(Authentication auth){
+        List<ProfessionalUsersDto> listProfDto = profUserService.findAllProfsDto(auth.getAuthorities());
 
         if(listProfDto == null){
             throw new EntityNotFoundException("No professional found");

--- a/src/main/java/com/NoviBackend/WalletWatch/user/professional/ProfUserService.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/user/professional/ProfUserService.java
@@ -75,7 +75,7 @@ public class ProfUserService {
         professionalUser.setCompany(request.getCompany());
         professionalUser.setShortIntroduction(request.getIntroduction());
 
-        // save into the profUser database
+        regularUserRepository.delete(regularUser);
         profUserRepository.save(professionalUser);
 
         // change authority to prof

--- a/src/main/java/com/NoviBackend/WalletWatch/user/professional/ProfUserService.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/user/professional/ProfUserService.java
@@ -3,6 +3,7 @@ package com.NoviBackend.WalletWatch.user.professional;
 import com.NoviBackend.WalletWatch.request.RequestPromote;
 import com.NoviBackend.WalletWatch.security.AuthenticationService;
 import com.NoviBackend.WalletWatch.subscription.SubscriptionRepository;
+import com.NoviBackend.WalletWatch.user.AbstractUsers;
 import com.NoviBackend.WalletWatch.user.dto.PersonalProfessionalUserDto;
 import com.NoviBackend.WalletWatch.user.dto.ProfessionalUsersDto;
 import com.NoviBackend.WalletWatch.user.dto.RegularUserCreationDto;
@@ -11,8 +12,12 @@ import com.NoviBackend.WalletWatch.user.regular.RegularUser;
 import com.NoviBackend.WalletWatch.user.regular.RegularUserRepository;
 import com.NoviBackend.WalletWatch.wallet.WalletRepository;
 import com.NoviBackend.WalletWatch.wallet.WalletService;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -40,10 +45,21 @@ public class ProfUserService {
     }
 
     // find
-    public List<ProfessionalUsersDto> findAllProfsDto() {
-        List<ProfessionalUser>  listProfessionals = profUserRepository.findAll();
+    public List<ProfessionalUsersDto> findAllProfsDto(Collection<? extends GrantedAuthority> authorities) {
 
-        // map users to Dto's
+        List<ProfessionalUser> listProfessionals = new ArrayList<>();
+
+        // if admin return all, else return with shared wallet
+        if(authorities.stream().anyMatch(ga -> ga.getAuthority().equals("ROLE_ADMIN"))){
+            listProfessionals = profUserRepository.findAll();
+        }else{
+            List<ProfessionalUser> allProfessionalUsers = profUserRepository.findAll();
+            for(ProfessionalUser prof: allProfessionalUsers){
+                if(prof.getPersonalWallet().getShared() == true){
+                    listProfessionals.add(prof);
+                }
+            }
+        }
         if(listProfessionals == null){
             return null;
         }

--- a/src/main/java/com/NoviBackend/WalletWatch/user/regular/RegularUser.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/user/regular/RegularUser.java
@@ -2,6 +2,7 @@ package com.NoviBackend.WalletWatch.user.regular;
 
 import com.NoviBackend.WalletWatch.user.AbstractUsers;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 @Entity
 public class RegularUser extends AbstractUsers {
@@ -14,7 +15,4 @@ public class RegularUser extends AbstractUsers {
         super(username, firstName, surname, emailAddress);
     }
 
-    public String becomeProfessionalUsers(){
-        return null;
-    }
 }

--- a/src/main/java/com/NoviBackend/WalletWatch/user/regular/RegularUserService.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/user/regular/RegularUserService.java
@@ -110,7 +110,6 @@ public class RegularUserService {
         }
 
         Long profId = profUserService.createProfessionalUser(regularUser, request);
-        removeRegularUser(regularUser);
 
         return profId;
     }

--- a/src/main/java/com/NoviBackend/WalletWatch/wallet/Wallet.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/wallet/Wallet.java
@@ -11,7 +11,7 @@ public class Wallet {
 
     // Attributes
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
     @Column


### PR DESCRIPTION
professional and regular users, see all the professionals who shared their wallet, at subdirectory /profs. 

AbstractUserClass became an MappedSuperClass again. The reasoning behind this choice, is that the excercie was to only use 6 to 7 entities. When im making the AbstarctClass the code would work better, but the requirements would not have been met. 

Because of this only RegularUsers and admin will be able to subscribe to professionals. Professionals can (for now) not subscribe. To fix this an extra entity needs to be made. 