### PR TITLE
Integration tests & first unittest -> AuthenticationService & new exceptionhander 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-api</artifactId>
 			<version>0.11.5</version>

--- a/src/main/java/com/NoviBackend/WalletWatch/exception/CustomizedResponseEntityExceptionHandler.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/exception/CustomizedResponseEntityExceptionHandler.java
@@ -1,18 +1,25 @@
 package com.NoviBackend.WalletWatch.exception;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
-@ControllerAdvice
+@RestControllerAdvice
 @RestController
-public class CustomizedResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+public class CustomizedResponseEntityExceptionHandler{
 
     @ExceptionHandler(Exception.class)
     public final ResponseEntity<Object> handleAllException(Exception ex,
@@ -57,5 +64,18 @@ public class CustomizedResponseEntityExceptionHandler extends ResponseEntityExce
                 new ExceptionResponse(new Date(), ex.getMessage(),
                         request.getDescription(false));
         return new ResponseEntity(exceptionResponse, HttpStatus.CONFLICT);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public Map<String, String> handleValidationExceptions(
+            MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+        return errors;
     }
 }

--- a/src/main/java/com/NoviBackend/WalletWatch/exception/CustomizedResponseEntityExceptionHandler.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/exception/CustomizedResponseEntityExceptionHandler.java
@@ -1,21 +1,15 @@
 package com.NoviBackend.WalletWatch.exception;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
-import org.springframework.validation.ObjectError;
-import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.WebRequest;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestControllerAdvice
 @RestController

--- a/src/main/java/com/NoviBackend/WalletWatch/request/LoginRequest.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/request/LoginRequest.java
@@ -4,6 +4,13 @@ public class LoginRequest {
     private String username;
     private String password;
 
+    public LoginRequest() {
+    }
+
+    public LoginRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
 
     public String getUsername() {
         return username;

--- a/src/main/java/com/NoviBackend/WalletWatch/security/AuthenticationService.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/security/AuthenticationService.java
@@ -7,7 +7,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
 

--- a/src/main/java/com/NoviBackend/WalletWatch/security/SecurityUser.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/security/SecurityUser.java
@@ -2,7 +2,9 @@ package com.NoviBackend.WalletWatch.security;
 
 import jakarta.persistence.*;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -24,7 +26,20 @@ public class SecurityUser {
             orphanRemoval = true,
             fetch = FetchType.EAGER)
     @JoinColumn(name="username")
-    private Set<Authority> authorities = new HashSet<>();
+    private List<Authority> authorities = new ArrayList<>();
+
+    public SecurityUser() {
+    }
+
+    public SecurityUser(String username,
+                        String password,
+                        boolean enabled,
+                        List<Authority> authorities) {
+        this.username = username;
+        this.password = password;
+        this.enabled = enabled;
+        this.authorities = authorities;
+    }
 
     public String getUsername() {
         return username;
@@ -50,11 +65,11 @@ public class SecurityUser {
         this.enabled = enabled;
     }
 
-    public Set<Authority> getAuthorities() {
+    public List<Authority> getAuthorities() {
         return authorities;
     }
 
-    public void setAuthorities(Set<Authority> authorities) {
+    public void setAuthorities(List<Authority> authorities) {
         this.authorities = authorities;
     }
 

--- a/src/main/java/com/NoviBackend/WalletWatch/user/dto/RegularUserCreationDto.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/user/dto/RegularUserCreationDto.java
@@ -1,11 +1,21 @@
 package com.NoviBackend.WalletWatch.user.dto;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public class RegularUserCreationDto {
+    @NotNull(message = "username is required")
     private String username;
+
+    @NotNull(message = "password must be greater then 8 characters")
+    @Size(min=8)
     private String password;
+
+    @NotNull(message = "First name is required")
     private String firstName;
+
+    @NotNull(message = "Please enter surname")
     private String surname;
 
     @Email

--- a/src/main/java/com/NoviBackend/WalletWatch/user/dto/RegularUserCreationDto.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/user/dto/RegularUserCreationDto.java
@@ -1,21 +1,22 @@
 package com.NoviBackend.WalletWatch.user.dto;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public class RegularUserCreationDto {
-    @NotNull(message = "username is required")
+    @NotBlank(message = "username is required")
     private String username;
 
-    @NotNull(message = "password must be greater then 8 characters")
-    @Size(min=8)
+    @NotNull(message = "password required")
+    @Size(min=8, message = "password must be greater then 8 characters")
     private String password;
 
-    @NotNull(message = "First name is required")
+    @NotBlank(message = "First name is required")
     private String firstName;
 
-    @NotNull(message = "Please enter surname")
+    @NotBlank(message = "Please enter surname")
     private String surname;
 
     @Email

--- a/src/main/java/com/NoviBackend/WalletWatch/user/regular/RegularUserController.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/user/regular/RegularUserController.java
@@ -7,6 +7,7 @@ import com.NoviBackend.WalletWatch.user.dto.RegularUserCreationDto;
 import com.NoviBackend.WalletWatch.user.dto.RegularUserDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -38,7 +39,7 @@ public class RegularUserController {
     }
 
     @PostMapping("/users")
-    public ResponseEntity<Object> createUser(@RequestBody RegularUserCreationDto userCreationDto) {
+    public ResponseEntity<Object> createUser(@RequestBody @Validated RegularUserCreationDto userCreationDto) {
         // check username and password
         regularUserService.usernameEmailCheck(userCreationDto);
 

--- a/src/main/java/com/NoviBackend/WalletWatch/user/regular/RegularUserService.java
+++ b/src/main/java/com/NoviBackend/WalletWatch/user/regular/RegularUserService.java
@@ -39,19 +39,13 @@ public class RegularUserService {
         if(id != 0)
             return id;
 
-        // map to user if ok
+        // create RegularUser
         RegularUser regularUser = userMapper.convertRegularUserCreationDtoToRegularUser(userDto);
-
-        // set wallet
         regularUser.setPersonalWallet(walletService.createWallet());
 
-        // save to regular user
-        regularUserRepository.save(regularUser);
+        Long regularUserId = saveUser(userDto, regularUser);
 
-        // save to auth and security user
-        authService.saveRegularUser(userDto);
-
-        return regularUser.getId();
+        return regularUserId;
     }
 
     public RegularUser findById(Long id) {
@@ -100,6 +94,16 @@ public class RegularUserService {
 
         // check if username or email in ProfessionalUser
         return profUserService.existsByUsernameAndEmail(user);
+    }
+
+    private Long saveUser(RegularUserCreationDto userDto, RegularUser regularUser){
+        // save to regular user
+        regularUserRepository.save(regularUser);
+
+        // save to auth and security user
+        authService.saveRegularUser(userDto);
+
+        return regularUser.getId();
     }
 }
 

--- a/src/test/java/com/NoviBackend/WalletWatch/WalletWatchApplicationTests.java
+++ b/src/test/java/com/NoviBackend/WalletWatch/WalletWatchApplicationTests.java
@@ -8,6 +8,7 @@ class WalletWatchApplicationTests {
 
 	@Test
 	void contextLoads() {
+
 	}
 
 }

--- a/src/test/java/com/NoviBackend/WalletWatch/integrationtests/IntegrationTests.java
+++ b/src/test/java/com/NoviBackend/WalletWatch/integrationtests/IntegrationTests.java
@@ -1,0 +1,89 @@
+package com.NoviBackend.WalletWatch.integrationtests;
+
+import com.NoviBackend.WalletWatch.user.dto.ProfessionalUsersDto;
+import com.NoviBackend.WalletWatch.user.professional.ProfUserRepository;
+import com.NoviBackend.WalletWatch.user.professional.ProfessionalUser;
+import com.NoviBackend.WalletWatch.wallet.Wallet;
+import com.NoviBackend.WalletWatch.wallet.WalletRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class IntegrationTests {
+
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private WalletRepository walletRepository;
+    @Autowired
+    private ProfUserRepository profUserRepository;
+
+
+    @Test
+    public void createUserTest() throws Exception{
+        String userJson = "{\"username\": \"wouter\"," +
+                "\"password\": \"pass\"," +
+                "\"firstName\": \"Wouter\"," +
+                "\"surname\": \"glassmaker\"," +
+                "\"emailAddress\": \"wouterglas@gmail.com\"}";
+
+        mvc.perform(MockMvcRequestBuilders.post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(userJson)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(MockMvcResultMatchers.header()
+                        .string("Location", "http://localhost/users/1"));
+    }
+
+    @Test
+    public void getProfsPageWithoutLoggedInUser() throws Exception{
+        mvc.perform(MockMvcRequestBuilders.get("/profs"))
+                .andExpect(MockMvcResultMatchers.status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", password = "verygoodpassword", roles="USER" )
+    public void getProfsId() throws Exception{
+        createProf();
+
+        MvcResult result = mvc.perform(MockMvcRequestBuilders.get("/profs/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        ProfessionalUsersDto prof = objectMapper.readValue(responseBody, ProfessionalUsersDto.class);
+
+        assertEquals("mario", prof.getUsername());
+        assertEquals("noviCollege", prof.getCompany());
+        assertEquals("i do not work here.", prof.getIntroduction());
+    }
+
+    private void createProf(){
+        ProfessionalUser prof = new ProfessionalUser("mario", "its", "me",
+                "itsme@mario.nl", "noviCollege", "i do not work here.");
+
+        Wallet wallet = new Wallet();
+
+        prof.setPersonalWallet(wallet);
+        prof.shareWallet(true);
+
+        walletRepository.save(wallet);
+        profUserRepository.save(prof);
+    }
+}

--- a/src/test/java/com/NoviBackend/WalletWatch/unittests/security/AuthenticationServiceTest.java
+++ b/src/test/java/com/NoviBackend/WalletWatch/unittests/security/AuthenticationServiceTest.java
@@ -1,0 +1,161 @@
+package com.NoviBackend.WalletWatch.unittests.security;
+
+import com.NoviBackend.WalletWatch.request.LoginRequest;
+import com.NoviBackend.WalletWatch.security.*;
+import com.NoviBackend.WalletWatch.user.dto.RegularUserCreationDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.server.ResponseStatusException;
+
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class AuthenticationServiceTest {
+
+    @Autowired
+    private AuthenticationService authService;
+
+    @MockBean
+    private SecurityUserRepository securityUserRepository;
+
+    @Mock
+    Authority authority;
+
+    @Mock
+    SecurityUser user;
+
+    @BeforeEach
+    void setup(){
+        // arrange
+        user = new SecurityUser();
+        user.setUsername("wouter");
+
+        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        user.setPassword(passwordEncoder.encode("password"));
+    }
+
+    @Test
+    void changeRole_ToAdmin() {
+        // Arrange
+        authority = new Authority("wouter", "ROLE_USER");
+        user.addAuthorities(authority);
+
+        Mockito.when(securityUserRepository.findSecurityUserByUsername("wouter"))
+                .thenReturn(Optional.ofNullable(user));
+
+        // act
+        authService.changeRole("wouter", "ROLE_ADMIN", "ROLE_USER");
+
+        // assert
+        assertEquals("ROLE_ADMIN", securityUserRepository
+                                                .findSecurityUserByUsername("wouter")
+                                                .get().getAuthorities()
+                                                .get(0).getAuthority());
+    }
+
+    @Test
+    void changeRole_WrongAuth(){
+        // arrange
+        authority = new Authority("wouter", "ROLE_PROF");
+        user.addAuthorities(authority);
+
+        Mockito.when(securityUserRepository.findSecurityUserByUsername("wouter"))
+                .thenReturn(Optional.ofNullable(user));
+
+        // act
+        authService.changeRole("wouter", "ROLE_ADMIN", "TEST_ROLE");
+
+        // assert
+        assertEquals("ROLE_PROF", securityUserRepository
+                .findSecurityUserByUsername("wouter")
+                .get().getAuthorities()
+                .get(0).getAuthority());
+    }
+
+    @Test
+    void changeRole_UserNotNull_AuthNotNull(){
+        // arrange
+        authority = new Authority();
+        authority.setUsername("testname");
+        user.addAuthorities(authority);
+
+        Mockito.when(securityUserRepository.findSecurityUserByUsername("wouter"))
+                .thenReturn(Optional.ofNullable(user));
+
+        // act & assert
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                authService.changeRole("wouter", "ROLE_ADMIN", null));
+    }
+
+    @Test
+    void checkCredentials_Correct_UsernamePassword() {
+        // arrange
+        LoginRequest request = new LoginRequest("wouter", "password");
+
+        Mockito.when(securityUserRepository.findSecurityUserByUsername("wouter"))
+                .thenReturn(Optional.ofNullable(user));
+
+        // act
+        boolean canLogin = authService.checkCredentials(request);
+
+        // assert
+        assertEquals(true, canLogin);
+    }
+
+    @Test
+    void checkCredentials_inCorrect_Password() {
+        // arrange
+        LoginRequest request = new LoginRequest("wouter", "not the password");
+
+        Mockito.when(securityUserRepository.findSecurityUserByUsername("wouter"))
+                .thenReturn(Optional.ofNullable(user));
+
+        // act
+        boolean canLogin = authService.checkCredentials(request);
+
+        // assert
+        assertEquals(false, canLogin);
+    }
+
+    @Test
+    void checkCredentials_NoPassword() {
+        // arrange
+        LoginRequest request = new LoginRequest("wouter", null);
+
+        Mockito.when(securityUserRepository.findSecurityUserByUsername("wouter"))
+                .thenReturn(Optional.ofNullable(user));
+
+        // act
+        boolean canLogin = authService.checkCredentials(request);
+
+        // assert
+        assertEquals(false, canLogin);
+    }
+
+    @Test
+    void saveRegularUser() {
+        // arrange
+        RegularUserCreationDto user = new RegularUserCreationDto("wouter", "password", "", "", "");
+
+        when(securityUserRepository.save(Mockito.any(SecurityUser.class)))
+                .thenAnswer(i -> i.getArguments()[0]);
+
+        // act
+
+    }
+
+    @Test
+    void findByUsername() {
+    }
+}


### PR DESCRIPTION
Intergration test:
* createUserTset(): a POST request at /users  to create a user. -> this integration tests check if a user is created and the return object. 
* getProfPageWithoutLoggedInUser(): chekcs the return status for when you try get /profs without being loggedin. 
* getProfsId(): some get request as getProfPageWithoutLoggedInUser(), only this time loggedin. 

Unittest:
* created 10 unittests whom togehter have a 100% line coverage all the mehtods inside AuthenticationService. 

Added 
- ExceptionHandler for AuthenticationService changeRole -> will return status 500 if somthing went wrong. 
- Exceptionhandler for the RegularUserCreationDto, will handle error for when users want te create a user with an emtpy field or when the password is shorter then 8 characters. 

Edited
- constructors in LoginRequest.
- AuthenticationService checkcredentials -> added "& request.getPassword != null". to "if(user!=null)". This way the password wont be checked if the request.password is empty. 
- RegularUserService -> splitted the saveRegularUser method. Now there is a public saveRegularUser function which calls a private createSecurityUser function. This makes the class more SOLID and cleaner to debug/read. 
